### PR TITLE
Moved testing dependencies into devDependencies (closes #5)

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,12 +4,13 @@
     "version": "0.0.4",
     "main": "parker.js",
     "dependencies": {
-        "chai": "*",
-        "mocha": "*",
         "underscore": "*",
-        "backbone": "*",
         "cli-color": "*",
         "minimist": "0.0.7"
+    },
+    "devDependencies": {
+        "chai": "*",
+        "mocha": "*"
     },
     "scripts": {
         "test": "mocha --no-colors --reporter spec"


### PR DESCRIPTION
This PR moves testing dependencies into the `devDependencies` section of `package.json`. It also removes `backbone` which does not appear to be used anywhere. See issue #5.
