### PR TITLE
added load stylesheets by directory feature

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
         "underscore": "*",
         "backbone": "*",
         "cli-color": "*",
-        "minimist": "0.0.7"
+        "minimist": "0.0.7",
+        "async": "~0.2.10"
     },
     "scripts": {
         "test": "mocha --no-colors --reporter spec"


### PR DESCRIPTION
I have updated so that you can now pass in `parker some/directory` and all .css files will be added. I didn't add support for `parker directory/*.css` as omitting the *.css does the same thing anyway. 

This could be updated to accept a wild card or maybe a regex that could be used to work out if the file should be included. Also maybe the ability to include css from nested directories - something like this `parker directory/**`?
