### PR TITLE
Replace underscore with lodash in all places

### DIFF
--- a/lib/CliFormatter.js
+++ b/lib/CliFormatter.js
@@ -2,7 +2,7 @@
 
 'use strict';
 
-var _ = require('underscore');
+var _ = require('lodash');
 
 function CliFormatter() {
 

--- a/lib/CssRule.js
+++ b/lib/CssRule.js
@@ -2,7 +2,7 @@
 
 'use strict';
 
-var _ = require('underscore');
+var _ = require('lodash');
 
 function CssRule(raw) {
     this.raw = raw;

--- a/lib/CssSelector.js
+++ b/lib/CssSelector.js
@@ -2,7 +2,7 @@
 
 'use strict';
 
-var _ = require('underscore');
+var _ = require('lodash');
 
 function CssSelector(raw) {
     this.raw = raw;

--- a/lib/CssStylesheet.js
+++ b/lib/CssStylesheet.js
@@ -2,7 +2,7 @@
 
 'use strict';
 
-var _ = require('underscore');
+var _ = require('lodash');
 
 function CssStylesheet(raw) {
     this.raw = raw;

--- a/lib/Formatters.js
+++ b/lib/Formatters.js
@@ -2,7 +2,7 @@
 
 'use strict';
 
-var _ = require('underscore'),
+var _ = require('lodash'),
     clc = require('cli-color');
 
 

--- a/lib/Parker.js
+++ b/lib/Parker.js
@@ -2,7 +2,7 @@
 
 'use strict';
 
-var _ = require('underscore'),
+var _ = require('lodash'),
     CssStylesheet = require('./CssStylesheet.js'),
     CssRule = require('./CssRule.js'),
     CssSelector = require('./CssSelector.js'),

--- a/metrics/IdentifiersPerSelector.js
+++ b/metrics/IdentifiersPerSelector.js
@@ -2,7 +2,7 @@
 
 'use strict';
 
-var _ = require('underscore');
+var _ = require('lodash');
 
 module.exports = {
     id: 'identifiers-per-selector',

--- a/metrics/MediaQueries.js
+++ b/metrics/MediaQueries.js
@@ -2,7 +2,7 @@
 
 'use strict';
 
-var _ = require('underscore');
+var _ = require('lodash');
 
 module.exports = {
     id: 'media-queries',

--- a/metrics/SpecificityPerSelector.js
+++ b/metrics/SpecificityPerSelector.js
@@ -2,7 +2,7 @@
 
 'use strict';
 
-var _ = require('underscore');
+var _ = require('lodash');
 
 module.exports = {
     id: 'specificity-per-selector',

--- a/metrics/TopSelectorSpecificity.js
+++ b/metrics/TopSelectorSpecificity.js
@@ -2,7 +2,7 @@
 
 'use strict';
 
-var _ = require('underscore');
+var _ = require('lodash');
 
 module.exports = {
     id: 'top-selector-specificity',

--- a/metrics/TopSelectorSpecificitySelector.js
+++ b/metrics/TopSelectorSpecificitySelector.js
@@ -2,7 +2,7 @@
 
 'use strict';
 
-var _ = require('underscore');
+var _ = require('lodash');
 
 module.exports = {
     id: 'top-selector-specificity-selector',

--- a/metrics/TotalIdSelectors.js
+++ b/metrics/TotalIdSelectors.js
@@ -3,7 +3,7 @@
 
 'use strict';
 
-var _ = require('underscore');
+var _ = require('lodash');
 
 module.exports = {
     id: 'total-id-selectors',

--- a/metrics/TotalIdentifiers.js
+++ b/metrics/TotalIdentifiers.js
@@ -2,7 +2,7 @@
 
 'use strict';
 
-var _ = require('underscore');
+var _ = require('lodash');
 
 module.exports = {
     id: 'total-identifiers',

--- a/metrics/TotalImportantKeywords.js
+++ b/metrics/TotalImportantKeywords.js
@@ -2,7 +2,7 @@
 
 'use strict';
 
-var _ = require('underscore');
+var _ = require('lodash');
 
 module.exports = {
     id: 'total-important-keywords',

--- a/metrics/TotalMediaQueries.js
+++ b/metrics/TotalMediaQueries.js
@@ -2,7 +2,7 @@
 
 'use strict';
 
-var _ = require('underscore');
+var _ = require('lodash');
 
 module.exports = {
     id: 'total-media-queries',

--- a/metrics/TotalSelectors.js
+++ b/metrics/TotalSelectors.js
@@ -2,7 +2,7 @@
 
 'use strict';
 
-var _ = require('underscore');
+var _ = require('lodash');
 
 module.exports = {
     id: 'total-selectors',

--- a/metrics/TotalUniqueColours.js
+++ b/metrics/TotalUniqueColours.js
@@ -2,7 +2,7 @@
 
 'use strict';
 
-var _ = require('underscore');
+var _ = require('lodash');
 
 module.exports = {
     id: 'total-unique-colours',

--- a/metrics/UniqueColours.js
+++ b/metrics/UniqueColours.js
@@ -2,7 +2,7 @@
 
 'use strict';
 
-var _ = require('underscore');
+var _ = require('lodash');
 
 module.exports = {
     id: 'unique-colours',

--- a/package.json
+++ b/package.json
@@ -1,30 +1,36 @@
 {
-    "name": "parker",
-    "description": "Stylesheet analysis tool for CSS",
-    "keywords": ["css","stylesheet","analysis"],
-    "version": "0.0.8",
-    "main": "parker.js",
-    "dependencies": {
-        "underscore": "*",
-        "cli-color": "*",
-        "minimist": "0.0.7",
-        "async": "~0.2.10",
-        "graceful-fs": "~3.0.2"
-    },
-    "devDependencies": {
-        "chai": "*",
-        "mocha": "*",
-        "sinon": "*",
-        "sinon-chai": "*"
-    },
-    "scripts": {
-        "test": "mocha --no-colors --reporter spec"
-    },
-    "bin": {"parker": "./parker.js"},
-    "homepage": "https://github.com/katiefenn/parker",
-    "bugs": "https://github.com/katiefenn/parker/issues",
-    "author": "Katie Fenn",
-    "repository": "https://github.com/katiefenn/parker",
-    "preferGlobal": true,
-    "license": "MIT"
+  "name": "parker",
+  "description": "Stylesheet analysis tool for CSS",
+  "keywords": [
+    "css",
+    "stylesheet",
+    "analysis"
+  ],
+  "version": "0.0.8",
+  "main": "parker.js",
+  "dependencies": {
+    "async": "~0.2.10",
+    "cli-color": "*",
+    "graceful-fs": "~3.0.2",
+    "lodash": "^3.2.0",
+    "minimist": "0.0.7"
+  },
+  "devDependencies": {
+    "chai": "*",
+    "mocha": "*",
+    "sinon": "*",
+    "sinon-chai": "*"
+  },
+  "scripts": {
+    "test": "mocha --no-colors --reporter spec"
+  },
+  "bin": {
+    "parker": "./parker.js"
+  },
+  "homepage": "https://github.com/katiefenn/parker",
+  "bugs": "https://github.com/katiefenn/parker/issues",
+  "author": "Katie Fenn",
+  "repository": "https://github.com/katiefenn/parker",
+  "preferGlobal": true,
+  "license": "MIT"
 }

--- a/parker.js
+++ b/parker.js
@@ -8,7 +8,7 @@
  * Module dependencies
  */
 
-var _ = require('underscore'),
+var _ = require('lodash'),
     Parker = require('./lib/Parker'),
     CliController = require('./lib/CliController'),
     metrics = require('./metrics/All'),


### PR DESCRIPTION
Updating underscore in all places with lodash, its more actively updated and optimized. Here's an quote from [this](http://joefleming.net/posts/use-lodash-instead-of-underscore/) article: 

 > There's no contest here. If you're using Underscore, anywhere (Node.js included), spend a few minutes right now and switch over to Lo-Dash. There's no reason not to, and a few great reasons (speed being the best) that you should, and you get those benefits for free!

Here are some more reference links:
- http://stackoverflow.com/questions/13789618/differences-between-lodash-and-underscore
- http://benmccormick.org/2014/11/12/underscore-vs-lodash/