### PR TITLE
Fixed total-id-selector reporting

### DIFF
--- a/metrics/TotalIdSelectors.js
+++ b/metrics/TotalIdSelectors.js
@@ -12,6 +12,19 @@ module.exports = {
     aggregate: 'sum',
     format: 'number',
     measure: function (selector) {
-        return selector.indexOf('#') > 0 ? 1 : 0;
+		var ids = 0;
+		var inBrackets = false;
+
+		_.forOwn(selector, function (char) {
+			if (char === '[') {
+				inBrackets = true;
+			} else if (char === ']') {
+				inBrackets = false;
+			} else if (char === '#' && !inBrackets) {
+				ids++;
+			}
+		});
+
+		return ids;
     }
 };

--- a/test/TotalIdSelectors.js
+++ b/test/TotalIdSelectors.js
@@ -1,0 +1,42 @@
+/*! Parker v0.0.0 - MIT license */
+
+var expect = require('chai').expect,
+	metric = require('../metrics/TotalIdSelectors.js');
+
+describe('The identifiers-per-selector metric', function () {
+	it('should provide a string identifier for the metric', function() {
+		expect(metric.id).to.be.a('string');
+	});
+
+	it('should provide a metric type', function() {
+		expect(metric.aggregate).to.match(/sum|mean/g);
+	});
+
+	it('should return 0 for an empty string', function () {
+		expect(metric.measure('')).to.equal(0);
+	});
+
+	it('should return 1 for the selector "#test"', function() {
+		expect(metric.measure('#test')).to.equal(1);
+	});
+
+	it('should return 1 for the selector "foo#test"', function() {
+		expect(metric.measure('foo#test')).to.equal(1);
+	});
+
+	it('should return 1 for the selector "foo #test"', function() {
+		expect(metric.measure('foo #test')).to.equal(1);
+	});
+
+	it('should return 0 for the selector "[href="#foo"]"', function () {
+		expect(metric.measure('[href="#foo"]')).to.equal(0);
+	});
+
+	it('should return 1 for the selector "[href="#foo"] #foo"', function () {
+		expect(metric.measure('[href="#foo"] #foo')).to.equal(1);
+	});
+
+	it('should return 2 for the selector "#foo #bar"', function () {
+		expect(metric.measure('#foo #bar')).to.equal(2);
+	});
+});


### PR DESCRIPTION
This fixes two bugs:

- `[href="#main"]` was returning "1" when in fact it isn't an ID
- `#main` was returning "0" when in fact it _is_ an ID

It's difficult to write a regular expression for this without negative lookbehind assertions, so I took this approach instead. I'll probably end up fixing more things in this library (such as the specificity calculator, which is still wrong), if many fixes are like this, I'll write a mini state machine thingy.

It's testing some *horrible* IDs, but I think that's a good assumption for a quality checker to make.

closes #28