### PR TITLE
Added csv to format list in help text

### DIFF
--- a/lib/Info.js
+++ b/lib/Info.js
@@ -37,6 +37,7 @@ module.exports = {
             'Formats List:',
             'human               Human-readable, newline separated format (default)',
             'json                JSON',
+            'csv                 CSV',
             '',
             'For more information, see ' + pkg.homepage
         ].forEach(function(str) { console.log(str); });


### PR DESCRIPTION
I noticed the functionality was there, but it wasn't mention in the help text. Simple tweak.