### PR TITLE
Update `graceful-fs` to version 4.2.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "async": "~0.2.10",
     "cli-color": "*",
-    "graceful-fs": "~3.0.2",
+    "graceful-fs": "4.2.6",
     "lodash": "^3.2.0",
     "minimist": "0.0.7"
   },


### PR DESCRIPTION
As noted in #56, and reiterated in #59, older versions of `graceful-fs`
don't play well with newer versions of Node.js. (See also
<https://stackoverflow.com/questions/55921442/>.) This commit bumps
`graceful-fs` to version 4.2.6, which fixed the issue on my machine, at
least (Node.js 15.8.0; npm 7.5.1).